### PR TITLE
Add proper variables for unjoin card

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -1403,6 +1403,9 @@ function cardMembers(userId, doc, fieldNames, modifier) {
         activityType: 'unjoinMember',
         boardId: doc.boardId,
         cardId: doc._id,
+        memberId,
+        listId: doc.listId,
+        swimlaneId: doc.swimlaneId,
       });
     }
   }


### PR DESCRIPTION
#2285 was a half-baked fix. unjoinMember was missing the same variables.